### PR TITLE
Dev/filtered order views

### DIFF
--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,0 +1,39 @@
+import {
+    addOrder,
+    addOrderItems,
+    removeAllOrderItems,
+    removeOrder,
+    removeOrderItems,
+} from '../actions/order';
+import {editOrder} from '../actions/activity';
+import {getId} from '../utils/id';
+import {
+    addOrderItem,
+    removeOrderItem,
+} from '../actions/order_item';
+
+export function addMenuItemToOrder(dispatch, orderId, menuItemId) {
+    const newOrderItemId = getId();
+    dispatch(addOrderItem(newOrderItemId, menuItemId));
+    dispatch(addOrderItems(orderId, newOrderItemId));
+}
+
+export function createAndEdiNewtOrder(dispatch) {
+    const newOrderId = getId();
+    dispatch(addOrder(newOrderId));
+    dispatch(editOrder(newOrderId));
+}
+
+export function deleteOrderItemFromOrder(dispatch, orderId, orderItemId) {
+    dispatch(removeOrderItems(orderId, orderItemId));
+    dispatch(removeOrderItem(orderItemId));
+}
+
+export function deleteOrder(dispatch, orderId) {
+    dispatch(removeAllOrderItems(orderId));
+    dispatch(removeOrder(orderId));
+}
+
+export function fulfillOrder(dispatch, orderId, orderItemIds) {
+
+}

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,9 +1,25 @@
+import {
+    ACTIVITY_STATE_EDIT_ORDER,
+    ACTIVITY_STATE_VIEW_FULFILLED_ORDERS,
+    ACTIVITY_STATE_VIEW_OPEN_ORDERS,
+} from '../actions/activity';
 import EditOrder from '../containers/edit_order';
+import FulfilledOrders from '../containers/fulfilled_orders';
+import OpenOrders from '../containers/open_orders';
 import React from 'react';
-import Navigation from './navigation';
+import Navigation from '../containers/navigation';
+
+const mapActivityStateToElementBuilder = {
+    [ACTIVITY_STATE_EDIT_ORDER]: () => { return <EditOrder/>; },
+    [ACTIVITY_STATE_VIEW_FULFILLED_ORDERS]: () => { return <FulfilledOrders/>; },
+    [ACTIVITY_STATE_VIEW_OPEN_ORDERS]: () => { return <OpenOrders/>; },
+};
 
 function getActivity(state, orderId) {
-    return <EditOrder/>;
+    var noop = () => {};
+    var elementBuilder = mapActivityStateToElementBuilder[state];
+    elementBuilder = elementBuilder || noop;
+    return elementBuilder();
 }
 
 export default function App({ state, orderId }) {

--- a/src/components/app.spec.js
+++ b/src/components/app.spec.js
@@ -1,7 +1,7 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 import App from './app';
-import Navigation from './navigation';
+import Navigation from '../containers/navigation';
 
 describe('components/app', function () {
     var component;

--- a/src/components/edit_order.js
+++ b/src/components/edit_order.js
@@ -24,8 +24,7 @@ function getOrderDetails({ order }) {
     return <OrderDetails
         id={order.id}
         price={order.price}
-        state={order.state}
-        summary={order.summary}
+        state={order.stateFormatted}
     />;
 }
 
@@ -44,7 +43,9 @@ export default function EditOrder(props) {
             <div className='half_width'>
                 <div className='bordered'>
                     { getOrderDetails(props) }
-                    { getOrderLineItems(props) }
+                    <div className='line_items_container'>
+                        { getOrderLineItems(props) }
+                    </div>
                 </div>
             </div>
             <div className='half_width'>

--- a/src/components/edit_order.scss
+++ b/src/components/edit_order.scss
@@ -1,0 +1,5 @@
+.sty_edit_order {
+    .line_items_container {
+        border-top: 1px solid gray;
+    }
+}

--- a/src/components/edit_order.spec.js
+++ b/src/components/edit_order.spec.js
@@ -32,7 +32,7 @@ describe('components/edit_order', function () {
                 }
             ],
             price: 1234,
-            state: 'Fulfilled',
+            stateFormatted: 'Fulfilled',
         };
         component = shallow(<EditOrder
             menuItems={menuItems}
@@ -59,8 +59,7 @@ describe('components/edit_order', function () {
         expect(matching.length).toEqual(1);
         expect(matching.props().id).toEqual(order.id);
         expect(matching.props().price).toEqual(order.price);
-        expect(matching.props().state).toEqual(order.state);
-        expect(matching.props().summary).toEqual(order.summary);
+        expect(matching.props().state).toEqual(order.stateFormatted);
     });
 
     it('should embed the OrderLineItems component', function () {

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,12 +1,34 @@
+import {
+    ACTIVITY_STATE_EDIT_ORDER,
+    ACTIVITY_STATE_VIEW_FULFILLED_ORDERS,
+    ACTIVITY_STATE_VIEW_OPEN_ORDERS,
+} from '../actions/activity';
 import React from 'react';
 
-export default function Navigation() {
+function getIsSelected(expectedState, actualState) {
+    return (expectedState === actualState) ? 'selected' : '';
+}
+
+export default function Navigation({ currentActivity, onCreateOrderClick, onViewFulfilledOrdersClick, onViewOpenOrdersClick }) {
     return (
         <nav className='sty_navigation wd_navigation'>
             <ul>
-                <li><a>Take An Order</a></li>
-                <li><a>View Open Orders</a></li>
-                <li><a>View Fulfilled Orders</a></li>
+                <li
+                    className={ getIsSelected(ACTIVITY_STATE_EDIT_ORDER, currentActivity) }
+                    onClick={onCreateOrderClick}
+                ><a>Take An Order</a></li>
+                <li
+                    className={ getIsSelected(ACTIVITY_STATE_VIEW_OPEN_ORDERS, currentActivity) }
+                    onClick={onViewOpenOrdersClick}
+                >
+                    <a>View Open Orders</a>
+                </li>
+                <li
+                    className={ getIsSelected(ACTIVITY_STATE_VIEW_FULFILLED_ORDERS, currentActivity) }
+                    onClick={onViewFulfilledOrdersClick}
+                >
+                    <a>View Fulfilled Orders</a><
+                /li>
             </ul>
         </nav>
     );

--- a/src/components/navigation.scss
+++ b/src/components/navigation.scss
@@ -10,7 +10,7 @@
         padding: 0.5em 0.25em;
         transition: background-color 0.4s;
 
-        &:hover {
+        &:hover, &.selected {
             background-color: #777;
         }
     }

--- a/src/components/order.js
+++ b/src/components/order.js
@@ -1,0 +1,72 @@
+import OrderDetails from './order_details';
+import OrderLineItems from './order_line_items';
+import React from 'react';
+
+export default class Order extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            drawerOpen: false,
+        };
+    }
+
+    getDrawerControl() {
+        const className = (this.state.drawerOpen) ? 'close_action' : 'open_action';
+        const newDrawerValue = !this.state.drawerOpen;
+        const text= (this.state.drawerOpen) ? '[-]' : '[+]';
+        return <div
+            className={className}
+            onClick={() => {
+                this.setState({
+                    drawerOpen: newDrawerValue,
+                });
+            }}
+        >{ text }</div>;
+    }
+
+    getOrderDetails({ order }) {
+        return <OrderDetails
+            id={order.id}
+            price={order.price}
+            state={order.stateFormatted}
+        />;
+    }
+
+    getOrderLineItems({order}) {
+        if (this.state.drawerOpen) {
+            return <tr className='line_items_container'>
+                <OrderLineItems
+                    orderId={order.id}
+                    orderItems={order.orderItems}
+                />
+            </tr>;
+        }
+    }
+
+    getOrderAction(onClick, text, order) {
+        if (onClick) {
+            return <button
+                onClick={() => { onClick(order.id); }}
+            >{ text}</button>;
+        }
+    }
+
+    getOrderActions(props) {
+        return <div>
+            { this.getOrderAction(props.onOrderEditClick, 'Edit', props.order) }
+            { this.getOrderAction(props.onOrderFulfillClick, 'Fulfill', props.order) }
+            { this.getOrderAction(props.onOrdeCancelClick, 'Cancel', props.order) }
+            { this.getOrderAction(props.onOrderCompleteClick, 'Complete', props.order) }
+        </div>;
+    }
+
+    render() {
+        return (
+            <tr className='sty_order wd_order'>
+                <td>{ this.getDrawerControl() }</td>
+                <td>{ this.getOrderDetails(this.props) }</td>
+                <td>{ this.getOrderActions(this.props) }</td>
+            </tr>
+        );
+    }
+}

--- a/src/components/order_details.js
+++ b/src/components/order_details.js
@@ -3,15 +3,21 @@ import React from 'react';
 
 export default function OrderDetails({ id, price, state, summary}) {
     return (
-        <div className='sty_order_details wd_order_details'>
-            <div className='primary_info'>
-                <div className='wd_id'>{ id }</div>
-                <div className='wd_summary'>{ summary }</div>
-            </div>
-            <div className='secondary_info'>
-                <div className='wd_price'>{ centsToDollars(price) }</div>
-                <div className='wd_state'>{ state }</div>
-            </div>
-        </div>
+        <table className='sty_order_details wd_order_details'>
+            <thead>
+                <tr>
+                    <th>Order #:</th>
+                    <th>State:</th>
+                    <th>Price:</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td className='wd_id'>{ id }</td>
+                    <td className='wd_state'>{ state }</td>
+                    <td className='wd_price'>{ centsToDollars(price) }</td>
+                </tr>
+            </tbody>
+        </table>
     );
 }

--- a/src/components/order_details.scss
+++ b/src/components/order_details.scss
@@ -1,0 +1,7 @@
+.sty_order_details {
+    width: 100%;
+
+    th, td {
+        text-align: left;
+    }
+}

--- a/src/components/order_details.spec.js
+++ b/src/components/order_details.spec.js
@@ -7,18 +7,15 @@ describe('components/order_details', function () {
     var id;
     var price;
     var state;
-    var summary;
 
     beforeEach(function () {
         id = 1111;
         price = 3025;
         state = 'Fulfilled';
-        summary = 'Burger (x4)';
         component = shallow(<OrderDetails
             id={id}
             price={price}
             state={state}
-            summary={summary}
         />);
     });
 
@@ -37,9 +34,5 @@ describe('components/order_details', function () {
 
     it('should display the correct state', function () {
         expect(component.find('.wd_state').text()).toEqual('Fulfilled');
-    });
-
-    it('should display the correct summary', function () {
-        expect(component.find('.wd_summary').text()).toEqual('Burger (x4)');
     });
 });

--- a/src/components/order_line_item.js
+++ b/src/components/order_line_item.js
@@ -15,7 +15,7 @@ export default function OrderLineItem(props) {
             <td className='wd_price'>{ centsToDollars(props.price) }</td>
             <td>
                 <button
-                    className='wd_delete'
+                    className='delete_column_content wd_delete'
                     onClick={ props.onDelete }
                 >X</button>
             </td>

--- a/src/components/order_line_item.scss
+++ b/src/components/order_line_item.scss
@@ -1,0 +1,5 @@
+.sty_order_line_item {
+    .delete_column_content {
+        float: right;
+    }
+}

--- a/src/components/order_line_items.scss
+++ b/src/components/order_line_items.scss
@@ -1,0 +1,3 @@
+.sty_order_line_items {
+    width: 100%;
+}

--- a/src/components/orders.js
+++ b/src/components/orders.js
@@ -1,0 +1,25 @@
+import Order from './order';
+import React from 'react';
+
+function mapToChildren(props) {
+    return props.orders.map((order) => {
+        return <Order
+            key={order.id}
+            order={order}
+            onOrdeCancelClick={props.onOrderCancelClick}
+            onOrderCompleteClick={props.onOrderCompleteClick}
+            onOrderFulfillClick={props.onOrderFulfillClick}
+            onOrderEditClick={props.onOrderEditClick}
+        />;
+    });
+}
+
+export default function Orders(props) {
+    return (
+        <table className='sty_orders wd_orders'>
+            <tbody>
+                { mapToChildren(props) }
+            </tbody>
+        </table>
+    );
+}

--- a/src/containers/edit_order.js
+++ b/src/containers/edit_order.js
@@ -1,110 +1,45 @@
-import {addOrderItem} from '../actions/order_item';
-import {editOrder} from '../actions/activity';
-import {ORDER_STATE_NEW, addOrderItems} from '../actions/order';
 import {connect} from 'react-redux';
-import {getId} from '../utils/id';
-import {removeOrderItem} from '../actions/order_item';
+import {changeOrderStateToOpen} from '../actions/order';
 import {
-    addOrder,
-    changeOrderStateToOpen,
-    removeAllOrderItems,
-    removeOrderItems,
-    removeOrder,
-} from '../actions/order';
+    addMenuItemToOrder,
+    createAndEdiNewtOrder,
+    deleteOrderItemFromOrder,
+    deleteOrder,
+} from '../commands/commands';
+import {
+    getCurrentActivityOrderId,
+    selectDenormalizedOrder
+} from '../selectors/order';
+import {selectAllMenuItems} from '../selectors/menu_item';
+
 import EditOrder from '../components/edit_order';
 import store from '../stores/store';
 
-function getOrderId(state) {
-    return state && state.activity && state.activity.order_id;
-}
-
-function getCurrentOrder(state) {
-    var orderId = getOrderId(state);
-    var order = state.orders[orderId];
-    return (orderId && order) ? order : undefined;
-}
-
-function createMenuItemViewModel(state, menuItemId) {
-    return state.menu_items[menuItemId];
-}
-
-function createMenuItemViewModels(state) {
-    return Object.values(state.menu_items);
-}
-
-function createOrderItemViewModel(state, orderItemId) {
-    var orderItem = state.order_items[orderItemId];
-    var orderItemModel = {
-        id: orderItemId,
-    };
-    orderItemModel.menuItem = createMenuItemViewModel(state, orderItem.menu_item_id);
-    return orderItemModel;
-}
-
-function getOrderHumanReadableState(order) {
-    // @TODO Make human-readable
-    return order.state;
-}
-
-function getOrderSummary(order) {
-    return 'A Summary';
-}
-
-function getOrderTotalPrice(order) {
-    return order.orderItems.reduce((prior, orderItem) => {
-        return prior + orderItem.menuItem.price;
-    }, 0);
-}
-
-function createOrderViewModel(state) {
-    var order = getCurrentOrder(state);
-    if (!order) {
-        return {};
-    }
-    var orderModel = {
-        id: order.id,
-    };
-    orderModel.orderItems = order.order_items.map((orderItemId) => {
-        return createOrderItemViewModel(state, orderItemId);
-    });
-    orderModel.price = getOrderTotalPrice(orderModel);
-    orderModel.state = getOrderHumanReadableState(order);
-    orderModel.summary = getOrderSummary(order);
-    return orderModel;
-}
-
 const mapStateToProps = (state) => {
     return {
-        menuItems: createMenuItemViewModels(state),
-        order: createOrderViewModel(state),
+        menuItems: selectAllMenuItems(state),
+        order: selectDenormalizedOrder(
+            state,
+            getCurrentActivityOrderId(state)
+        ),
     };
 };
-
-function resetEditor(dispatch) {
-    var newOrderId = getId();
-    dispatch(addOrder(newOrderId));
-    dispatch(editOrder(newOrderId));
-}
 
 const mapDispatchToProps = (dispatch) => {
     return {
         onMenuItemClick: (menuItemId, orderId) => {
-            var orderItemId = getId();
-            dispatch(addOrderItem(orderItemId, menuItemId));
-            dispatch(addOrderItems(orderId, orderItemId));
+            addMenuItemToOrder(dispatch, orderId, menuItemId);
         },
         onOrderCancelClick: (orderId) => {
-            dispatch(removeAllOrderItems(orderId));
-            dispatch(removeOrder(orderId));
-            resetEditor(dispatch);
+            deleteOrder(dispatch, orderId);
+            createAndEdiNewtOrder(dispatch);
         },
         onOrderSaveClick: (orderId) => {
             dispatch(changeOrderStateToOpen(orderId));
-            resetEditor(dispatch);
+            createAndEdiNewtOrder(dispatch);
         },
         onOrderItemDelete: (orderItemId, orderId) => {
-            dispatch(removeOrderItems(orderId, orderItemId));
-            dispatch(removeOrderItem(orderItemId));
+            deleteOrderItemFromOrder(dispatch, orderId, orderItemId);
         },
     };
 };

--- a/src/containers/fulfilled_orders.js
+++ b/src/containers/fulfilled_orders.js
@@ -1,0 +1,32 @@
+import {
+    ORDER_STATE_FULFILLED,
+    changeOrderStateToCancelled,
+    changeOrderStateToCompleted,
+} from '../actions/order';
+import {connect} from 'react-redux';
+import {selectDenormalizedFilteredOrders} from '../selectors/order';
+import Orders from '../components/orders';
+
+const mapStateToProps = (state) => {
+    return {
+        orders: selectDenormalizedFilteredOrders(state, (order) => {
+            return order.state === ORDER_STATE_FULFILLED;
+        }),
+    };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        onOrderCancelClick: (orderId) =>  {
+            dispatch(changeOrderStateToCancelled(orderId));
+        },
+        onOrderCompleteClick: (orderId) => {
+            dispatch(changeOrderStateToCompleted(orderId));
+        },
+    };
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Orders);

--- a/src/containers/navigation.js
+++ b/src/containers/navigation.js
@@ -1,0 +1,33 @@
+import {connect} from 'react-redux';
+import {createAndEdiNewtOrder} from '../commands/commands';
+import {
+    viewFulfilledOrders,
+    viewOpenOrders,
+} from '../actions/activity';
+import {getCurrentActivity} from '../selectors/activity';
+import Navigation from '../components/navigation';
+
+const mapStateToProps = (state) => {
+    return {
+        currentActivity: getCurrentActivity(state),
+    };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        onCreateOrderClick: () => {
+            createAndEdiNewtOrder(dispatch);
+        },
+        onViewFulfilledOrdersClick: () => {
+            dispatch(viewFulfilledOrders());
+        },
+        onViewOpenOrdersClick: () => {
+            dispatch(viewOpenOrders());
+        }
+    };
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Navigation);

--- a/src/containers/open_orders.js
+++ b/src/containers/open_orders.js
@@ -1,0 +1,28 @@
+import {
+    ORDER_STATE_OPEN,
+    changeOrderStateToFulfilled,
+} from '../actions/order';
+import {connect} from 'react-redux';
+import {selectDenormalizedFilteredOrders} from '../selectors/order';
+import Orders from '../components/orders';
+
+const mapStateToProps = (state) => {
+    return {
+        orders: selectDenormalizedFilteredOrders(state, (order) => {
+            return order.state === ORDER_STATE_OPEN;
+        }),
+    };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        onOrderFulfillClick: (orderId) => {
+            dispatch(changeOrderStateToFulfilled(orderId));
+        },
+    };
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Orders);

--- a/src/selectors/activity.js
+++ b/src/selectors/activity.js
@@ -1,0 +1,3 @@
+export function getCurrentActivity(state) {
+    return state.activity.state;
+}

--- a/src/selectors/menu_item.js
+++ b/src/selectors/menu_item.js
@@ -1,0 +1,7 @@
+export function selectMenuItem(state, menuItemId) {
+    return state.menu_items[menuItemId];
+}
+
+export function selectAllMenuItems(state) {
+    return Object.values(state.menu_items);
+}

--- a/src/selectors/order.js
+++ b/src/selectors/order.js
@@ -1,0 +1,89 @@
+import {selectDenormalizedOrderItems} from './order_item';
+import {
+    ORDER_STATE_NEW,
+    ORDER_STATE_OPEN,
+    ORDER_STATE_FULFILLED,
+    ORDER_STATE_COMPLETED,
+    ORDER_STATE_CANCELLED,
+} from '../actions//order';
+
+const orderStatesToFormattedValues = {
+    [ORDER_STATE_NEW]: 'New',
+    [ORDER_STATE_OPEN]: 'Open',
+    [ORDER_STATE_FULFILLED]: 'Fulfilled',
+    [ORDER_STATE_COMPLETED]: 'Completed',
+    [ORDER_STATE_CANCELLED]: 'Cancelled',
+};
+
+function getOrderSummary(order) {
+    return 'A Summary';
+}
+
+export function getCurrentActivityOrderId(state) {
+    return state && state.activity && state.activity.order_id;
+}
+
+export function selectDenormalizedFilteredOrders(state, filter) {
+    return selectFilteredOrders(state, filter)
+        .map((order) => {
+            return selectDenormalizedOrder(state, order.id);
+        })
+        .filter((order) => {
+            return order !== undefined;
+        });
+
+}
+
+export function selectDenormalizedOrder(state, orderId) {
+    const order = selectOrder(state, orderId);
+    if (!order) {
+        return undefined;
+    }
+    return (order === undefined) ? undefined : {
+        id: order.id,
+        orderItems: selectDenormalizedOrderItems(state, order.order_items),
+        price: selectOrderTotalPrice(state, orderId),
+        state: order.state,
+        stateFormatted: selectOrderFormattedState(state, orderId),
+    };
+}
+
+export function selectFilteredOrders(state, filter) {
+    return Object.values(state.orders)
+        .filter(filter)
+        .map((order) => {
+            return order;
+        });
+
+}
+
+export function selectOrder(state, orderId) {
+    return state.orders[orderId];
+}
+
+export function selectOrders(state, orderIds) {
+    return orderIds
+        .map((orderId) => {
+            return selectOrder(orderId);
+        })
+        .filter((order) => {
+            return order !== undefined;
+        });
+}
+
+export function selectOrderFormattedState(state, orderId) {
+    const order = selectOrder(state, orderId);
+    return (order === undefined)
+        ? undefined
+        : orderStatesToFormattedValues[order.state];
+}
+
+export function selectOrderTotalPrice(state, orderId) {
+    const order = selectOrder(state, orderId);
+    return (order === undefined)
+        ? undefined
+        : selectDenormalizedOrderItems(state, order.order_items)
+            .reduce((prior, orderItem) => {
+                return prior + orderItem.menuItem.price;
+            }, 0);
+}

--- a/src/selectors/order_item.js
+++ b/src/selectors/order_item.js
@@ -1,0 +1,23 @@
+import {selectMenuItem} from './menu_item';
+
+export function selectDenormalizedOrderItem(state, orderItemId) {
+    const orderItem = selectOrderItem(state, orderItemId);
+    return (orderItem === undefined) ? undefined : {
+        id: orderItemId,
+        menuItem: selectMenuItem(state, orderItem.menu_item_id),
+    };
+}
+
+export function selectDenormalizedOrderItems(state, orderItemIds) {
+    return orderItemIds
+        .map((orderItemId) => {
+            return selectDenormalizedOrderItem(state, orderItemId);
+        })
+        .filter((orderItem) => {
+            return orderItem !== undefined;
+        });
+}
+
+export function selectOrderItem(state, orderItemId) {
+    return state.order_items[orderItemId];
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -23,4 +23,8 @@ button {
     width: 50%;
 }
 
+@import '../components/edit_order.scss';
 @import '../components/navigation.scss';
+@import '../components/order_details.scss';
+@import '../components/order_line_item.scss';
+@import '../components/order_line_items.scss';


### PR DESCRIPTION
https://trello.com/c/qTTw3yEp/4-have-a-way-to-view-current-open-orders-and-then-close-them-when-they-re-handed-to-customers
https://trello.com/c/930WCBys/3-handle-a-case-where-someone-has-decided-to-cancel-an-order-once-they-get-to-the-window

This PR adds open and fulfilled order components to the drive-thru app, alongside some style and markup cleanup for the edit order components.