### PR TITLE
Reorganize state API to handle editing existing orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.3",
-    "redux": "^3.6.0",
-    "underscore": "^1.8.3"
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "babel-core": "^6.24.0",

--- a/src/actions/order.js
+++ b/src/actions/order.js
@@ -12,29 +12,11 @@ export const ORDER_STATE_FULFILLED = 'state:order:fulfilled';
 export const ORDER_STATE_COMPLETED = 'state:order:completed';
 export const ORDER_STATE_CANCELLED = 'state:order:cancelled';
 
-function wrapInArray(value) {
-    if (Array.isArray(value)) {
-        return value;
-    }
-    return [value];
-}
-
-export function addOrder(id, order_items = []) {
-    order_items = wrapInArray(order_items);
+export function addOrder(id) {
     return {
         type: ADD_ORDER,
         id,
-        order_items,
         state: ORDER_STATE_NEW,
-    };
-}
-
-export function addOrderItems(id, order_items = []) {
-    order_items = wrapInArray(order_items);
-    return {
-        type: ADD_ORDER_ITEMS,
-        id,
-        order_items,
     };
 }
 
@@ -81,14 +63,5 @@ export function removeOrder(id) {
     return {
         type: REMOVE_ORDER,
         id,
-    };
-}
-
-export function removeOrderItems(id, order_items = []) {
-    order_items = wrapInArray(order_items);
-    return {
-        type: REMOVE_ORDER_ITEMS,
-        id,
-        order_items,
     };
 }

--- a/src/actions/order.spec.js
+++ b/src/actions/order.spec.js
@@ -13,74 +13,21 @@ import {
     ORDER_STATE_CANCELLED,
 
     addOrder,
-    addOrderItems,
     changeOrderStateToOpen,
     changeOrderStateToFulfilled,
     changeOrderStateToCompleted,
     changeOrderStateToCancelled,
-    removeAllOrderItems,
     removeOrder,
-    removeOrderItems,
 } from './order';
 
 describe('actions/order', function () {
     describe('when calling addOrder', function () {
-        it('should return an action when not passing order_items', function () {
+        it('should return an action', function () {
             var actual = addOrder(1111);
             expect(actual).toEqual({
                 type: ADD_ORDER,
                 id: 1111,
-                order_items: [],
                 state: ORDER_STATE_NEW,
-            });
-        });
-
-        it('should return an action when passing a single order_item', function () {
-            var actual = addOrder(1111, 2222);
-            expect(actual).toEqual({
-                type: ADD_ORDER,
-                id: 1111,
-                order_items: [2222],
-                state: ORDER_STATE_NEW,
-            });
-        });
-
-        it('should return an action when passing an array of order_items', function () {
-            var actual = addOrder(1111, [2222, 3333]);
-            expect(actual).toEqual({
-                type: ADD_ORDER,
-                id: 1111,
-                order_items: [2222, 3333],
-                state: ORDER_STATE_NEW,
-            });
-        });
-    });
-
-    describe('when calling addOrderItems', function () {
-        it('should return an action when not passing order_items', function () {
-            var actual = addOrderItems(1111);
-            expect(actual).toEqual({
-                type: ADD_ORDER_ITEMS,
-                id: 1111,
-                order_items: [],
-            });
-        });
-
-        it('should return an action when passing an single order_item', function () {
-            var actual = addOrderItems(1111, 2222);
-            expect(actual).toEqual({
-                type: ADD_ORDER_ITEMS,
-                id: 1111,
-                order_items: [2222],
-            });
-        });
-
-        it('should return an action when passing an array of order_items', function () {
-            var actual = addOrderItems(1111, [2222, 3333]);
-            expect(actual).toEqual({
-                type: ADD_ORDER_ITEMS,
-                id: 1111,
-                order_items: [2222, 3333],
             });
         });
     });
@@ -121,48 +68,11 @@ describe('actions/order', function () {
         });
     });
 
-    it('should return an action when calling removeAllOrderItems', function () {
-        var actual = removeAllOrderItems(1111);
-        expect(actual).toEqual({
-            type: REMOVE_ALL_ORDER_ITEMS,
-            id: 1111,
-        });
-    });
-
     it('should return an action when calling removeOrder', function () {
         var actual = removeOrder(1111);
         expect(actual).toEqual({
             type: REMOVE_ORDER,
             id: 1111,
-        });
-    });
-
-    describe('when calling removeOrderItems', function () {
-        it('should return an action when not passing order_items', function () {
-            var actual = removeOrderItems(1111);
-            expect(actual).toEqual({
-                type: REMOVE_ORDER_ITEMS,
-                id: 1111,
-                order_items: [],
-            });
-        });
-
-        it('should return an action when passing an single order_item', function () {
-            var actual = removeOrderItems(1111, 2222);
-            expect(actual).toEqual({
-                type: REMOVE_ORDER_ITEMS,
-                id: 1111,
-                order_items: [2222],
-            });
-        });
-
-        it('should return an action when passing an array of order_items', function () {
-            var actual = removeOrderItems(1111, [2222, 3333]);
-            expect(actual).toEqual({
-                type: REMOVE_ORDER_ITEMS,
-                id: 1111,
-                order_items: [2222, 3333],
-            });
         });
     });
 });

--- a/src/actions/order_item.js
+++ b/src/actions/order_item.js
@@ -1,31 +1,33 @@
 export const ADD_ORDER_ITEM = 'actions:order_item:add';
-export const CHANGE_ORDER_ITEM_STATE = 'actions:order_item:change_state';
+export const CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID = 'actions:order_item:change_state_by_order_id';
 export const REMOVE_ORDER_ITEM = 'actions:order_item:remove';
+export const REMOVE_OPEN_ORDER_ITEMS_BY_ORDER = 'actions:order_item:remove_open_by_order';
 
 export const ORDER_ITEM_STATE_OPEN = 'state:order_item:open';
 export const ORDER_ITEM_STATE_FULFILLED = 'state:order_item:fulfilled';
 
-export function addOrderItem(id, menu_item_id) {
+export function addOrderItem(id, menu_item_id, order_id) {
     return {
         type: ADD_ORDER_ITEM,
         id,
         menu_item_id,
+        order_id,
         state: ORDER_ITEM_STATE_OPEN,
     };
 }
 
-export function changeOrderItemStateToFulfilled(id) {
+export function changeOrderItemStateToFulfilledByOrderId(order_id) {
     return {
-        type: CHANGE_ORDER_ITEM_STATE,
-        id,
+        type: CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
+        order_id,
         state: ORDER_ITEM_STATE_FULFILLED,
     };
 }
 
-export function changeOrderItemStateToOpen(id) {
+export function changeOrderItemStateToOpenByOrderId(order_id) {
     return {
-        type: CHANGE_ORDER_ITEM_STATE,
-        id,
+        type: CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
+        order_id,
         state: ORDER_ITEM_STATE_OPEN,
     };
 }
@@ -34,5 +36,13 @@ export function removeOrderItem(id) {
     return {
         type: REMOVE_ORDER_ITEM,
         id,
+    };
+}
+
+export function removeOpenOrderItemsByOrder(order_id) {
+    return {
+        type: REMOVE_OPEN_ORDER_ITEMS_BY_ORDER,
+        order_id,
+        state: ORDER_ITEM_STATE_OPEN,
     };
 }

--- a/src/actions/order_item.spec.js
+++ b/src/actions/order_item.spec.js
@@ -1,14 +1,14 @@
 import {
     ADD_ORDER_ITEM,
-    CHANGE_ORDER_ITEM_STATE,
+    CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
     REMOVE_ORDER_ITEM,
 
     ORDER_ITEM_STATE_OPEN,
     ORDER_ITEM_STATE_FULFILLED,
 
     addOrderItem,
-    changeOrderItemStateToFulfilled,
-    changeOrderItemStateToOpen,
+    changeOrderItemStateToFulfilledByOrderId,
+    changeOrderItemStateToOpenByOrderId,
     removeOrderItem,
 } from './order_item';
 
@@ -24,19 +24,19 @@ describe('actions/order_item', () => {
     });
 
     it('should return an action to change state when calling changeOrderItemStateToFulfilled', function () {
-        var actual = changeOrderItemStateToFulfilled(1111);
+        var actual = changeOrderItemStateToFulfilledByOrderId(1111);
         expect(actual).toEqual({
-            type: CHANGE_ORDER_ITEM_STATE,
-            id: 1111,
+            type: CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
+            order_id: 1111,
             state: ORDER_ITEM_STATE_FULFILLED,
         });
     });
 
     it('should return an action to change state when calling changeOrderItemStateToOpen', function () {
-        var actual = changeOrderItemStateToOpen(1111);
+        var actual = changeOrderItemStateToOpenByOrderId(1111);
         expect(actual).toEqual({
-            type: CHANGE_ORDER_ITEM_STATE,
-            id: 1111,
+            type: CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
+            order_id: 1111,
             state: ORDER_ITEM_STATE_OPEN,
         });
     });

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,21 +1,25 @@
 import {
     addOrder,
-    addOrderItems,
-    removeAllOrderItems,
+    changeOrderStateToFulfilled,
     removeOrder,
-    removeOrderItems,
 } from '../actions/order';
-import {editOrder} from '../actions/activity';
+import {
+    changeOrderItemStateToFulfilledByOrderId,
+} from '../actions/order_item';
+import {
+    editOrder,
+    viewFulfilledOrders,
+} from '../actions/activity';
 import {getId} from '../utils/id';
 import {
     addOrderItem,
     removeOrderItem,
+    removeOpenOrderItemsByOrder,
 } from '../actions/order_item';
 
 export function addMenuItemToOrder(dispatch, orderId, menuItemId) {
     const newOrderItemId = getId();
-    dispatch(addOrderItem(newOrderItemId, menuItemId));
-    dispatch(addOrderItems(orderId, newOrderItemId));
+    dispatch(addOrderItem(newOrderItemId, menuItemId, orderId));
 }
 
 export function createAndEdiNewtOrder(dispatch) {
@@ -24,16 +28,17 @@ export function createAndEdiNewtOrder(dispatch) {
     dispatch(editOrder(newOrderId));
 }
 
-export function deleteOrderItemFromOrder(dispatch, orderId, orderItemId) {
-    dispatch(removeOrderItems(orderId, orderItemId));
-    dispatch(removeOrderItem(orderItemId));
-}
-
 export function deleteOrder(dispatch, orderId) {
-    dispatch(removeAllOrderItems(orderId));
+    dispatch(removeOpenOrderItemsByOrder(orderId));
     dispatch(removeOrder(orderId));
 }
 
-export function fulfillOrder(dispatch, orderId, orderItemIds) {
+export function cancelOrderChanges(dispatch, orderId) {
+    dispatch(removeOpenOrderItemsByOrder(orderId));
+    dispatch(viewFulfilledOrders());
+}
 
+export function fulfillOrder(dispatch, orderId) {
+    dispatch(changeOrderStateToFulfilled(orderId));
+    dispatch(changeOrderItemStateToFulfilledByOrderId(orderId));
 }

--- a/src/components/edit_order.js
+++ b/src/components/edit_order.js
@@ -8,7 +8,7 @@ function getEditOrderActions({ order, onOrderCancelClick, onOrderSaveClick }) {
     return <EditOrderActions
         onOrderCancelClick={onOrderCancelClick}
         onOrderSaveClick={onOrderSaveClick}
-        orderId={order.id}
+        order={order}
     />;
 }
 

--- a/src/components/edit_order_actions.js
+++ b/src/components/edit_order_actions.js
@@ -1,15 +1,15 @@
 import React from 'react';
 
-export default function EditOrderActions({ orderId, onOrderCancelClick, onOrderSaveClick }) {
+export default function EditOrderActions({ order, onOrderCancelClick, onOrderSaveClick }) {
     return (
         <div className='sty_edit_order_actions wd_edit_order_actions bordered'>
             <button
                 className='wd_cancel'
-                onClick={() => { onOrderCancelClick(orderId); }}
+                onClick={() => { onOrderCancelClick(order.id, order.state); }}
             >Cancel</button>
             <button
                 className='wd_save'
-                onClick={() => { onOrderSaveClick(orderId); }}
+                onClick={() => { onOrderSaveClick(order.id, order.state); }}
             >Save</button>
         </div>
     );

--- a/src/components/edit_order_actions.spec.js
+++ b/src/components/edit_order_actions.spec.js
@@ -5,14 +5,18 @@ import EditOrderActions from './edit_order_actions';
 describe('./components/edit_order_actions', function () {
     var onOrderCancelClick = jest.fn();
     var onOrderSaveClick = jest.fn();
-    var orderId;
+    var order;
     var component;
 
     beforeEach(function () {
+        order = {
+            id: 1111,
+            state: 'foo',
+        };
         component = shallow(<EditOrderActions
             onOrderCancelClick={onOrderCancelClick}
             onOrderSaveClick={onOrderSaveClick}
-            orderId={orderId}
+            order={order}
         />);
     });
 
@@ -24,14 +28,14 @@ describe('./components/edit_order_actions', function () {
     describe('when clicking cancel', function () {
         it('should call the onClick fn', function () {
             component.find('.wd_cancel').simulate('click');
-            expect(onOrderCancelClick).toBeCalledWith(orderId);
+            expect(onOrderCancelClick).toBeCalledWith(order.id, order.state);
         });
     });
 
     describe('when clicking save', function () {
         it('should call the onClick fn', function () {
             component.find('.wd_save').simulate('click');
-            expect(onOrderSaveClick).toBeCalledWith(orderId);
+            expect(onOrderSaveClick).toBeCalledWith(order.id, order.state);
         });
     });
 });

--- a/src/components/order_line_item.js
+++ b/src/components/order_line_item.js
@@ -1,16 +1,21 @@
 import {centsToDollars} from './utils/formatting';
+import {ORDER_ITEM_STATE_FULFILLED} from '../actions/order_item';
 import React from 'react';
 
-function getClassname(id) {
-    return [
+function getClassname({ id, state}) {
+    var classes = [
         'sty_order_line_item',
         'wd_order_line_item_' + id,
-    ].join(' ');
+    ];
+    if (state === ORDER_ITEM_STATE_FULFILLED) {
+        classes.push('fulfilled');
+    }
+    return classes.join(' ');
 }
 
 export default function OrderLineItem(props) {
     return (
-        <tr className={ getClassname(props.id) }>
+        <tr className={ getClassname(props) }>
             <td className='wd_name'>{ props.name }</td>
             <td className='wd_price'>{ centsToDollars(props.price) }</td>
             <td>

--- a/src/components/order_line_item.scss
+++ b/src/components/order_line_item.scss
@@ -2,4 +2,8 @@
     .delete_column_content {
         float: right;
     }
+    
+    &.fulfilled {
+        background-color: beige;
+    }
 }

--- a/src/components/order_line_items.js
+++ b/src/components/order_line_items.js
@@ -9,6 +9,7 @@ function mapToChildren({ onOrderItemDelete, orderItems, orderId }) {
             name={orderItem.menuItem.name}
             onDelete={() => { onOrderItemDelete(orderItem.id, orderId); }}
             price={orderItem.menuItem.price}
+            state={orderItem.state}
         />;
     });
 }

--- a/src/containers/edit_order.js
+++ b/src/containers/edit_order.js
@@ -1,9 +1,14 @@
 import {connect} from 'react-redux';
-import {changeOrderStateToOpen} from '../actions/order';
+import {viewFulfilledOrders} from '../actions/activity';
+import {
+    ORDER_STATE_NEW,
+    changeOrderStateToOpen
+} from '../actions/order';
+import {removeOrderItem} from '../actions/order_item';
 import {
     addMenuItemToOrder,
+    cancelOrderChanges,
     createAndEdiNewtOrder,
-    deleteOrderItemFromOrder,
     deleteOrder,
 } from '../commands/commands';
 import {
@@ -30,16 +35,24 @@ const mapDispatchToProps = (dispatch) => {
         onMenuItemClick: (menuItemId, orderId) => {
             addMenuItemToOrder(dispatch, orderId, menuItemId);
         },
-        onOrderCancelClick: (orderId) => {
-            deleteOrder(dispatch, orderId);
-            createAndEdiNewtOrder(dispatch);
+        onOrderCancelClick: (orderId, orderState) => {
+            if (orderState === ORDER_STATE_NEW) {
+                deleteOrder(dispatch, orderId);
+                createAndEdiNewtOrder(dispatch);
+            } else {
+                cancelOrderChanges(dispatch);
+            }
         },
-        onOrderSaveClick: (orderId) => {
+        onOrderSaveClick: (orderId, orderState) => {
             dispatch(changeOrderStateToOpen(orderId));
-            createAndEdiNewtOrder(dispatch);
+            if (orderState === ORDER_STATE_NEW) {
+                createAndEdiNewtOrder(dispatch);
+            } else {
+                dispatch(viewFulfilledOrders());
+            }
         },
         onOrderItemDelete: (orderItemId, orderId) => {
-            deleteOrderItemFromOrder(dispatch, orderId, orderItemId);
+            dispatch(removeOrderItem(orderItemId));
         },
     };
 };

--- a/src/containers/fulfilled_orders.js
+++ b/src/containers/fulfilled_orders.js
@@ -4,6 +4,7 @@ import {
     changeOrderStateToCompleted,
 } from '../actions/order';
 import {connect} from 'react-redux';
+import {editOrder} from '../actions/activity';
 import {selectDenormalizedFilteredOrders} from '../selectors/order';
 import Orders from '../components/orders';
 
@@ -22,6 +23,9 @@ const mapDispatchToProps = (dispatch) => {
         },
         onOrderCompleteClick: (orderId) => {
             dispatch(changeOrderStateToCompleted(orderId));
+        },
+        onOrderEditClick: (orderId) => {
+            dispatch(editOrder(orderId));
         },
     };
 };

--- a/src/containers/open_orders.js
+++ b/src/containers/open_orders.js
@@ -3,6 +3,7 @@ import {
     changeOrderStateToFulfilled,
 } from '../actions/order';
 import {connect} from 'react-redux';
+import {fulfillOrder} from '../commands/commands';
 import {
     selectDenormalizedFilteredOrders,
     selectAlertFromOrders,
@@ -21,7 +22,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
     return {
         onOrderFulfillClick: (orderId) => {
-            dispatch(changeOrderStateToFulfilled(orderId));
+            fulfillOrder(dispatch, orderId);
         },
     };
 };

--- a/src/reducers/order_items.js
+++ b/src/reducers/order_items.js
@@ -1,7 +1,8 @@
 import {
     ADD_ORDER_ITEM,
-    CHANGE_ORDER_ITEM_STATE,
+    CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID,
     REMOVE_ORDER_ITEM,
+    REMOVE_OPEN_ORDER_ITEMS_BY_ORDER,
 } from '../actions/order_item';
 
 function addOrderItem(state, action) {
@@ -9,17 +10,24 @@ function addOrderItem(state, action) {
         [action.id]: {
             id: action.id,
             menu_item_id: action.menu_item_id,
+            order_id: action.order_id,
             state: action.state,
         },
     });
 }
 
-function changeOrderItemState(state, action) {
+function changeOrderItemStateByOrderId(state, action) {
     var newState = Object.assign({}, state);
-    var orderItem = newState[action.id];
-    if (orderItem) {
-        orderItem.state = action.state;
-    }
+    Object.keys(newState)
+        .map((newStateId) => {
+            return newState[newStateId];
+        })
+        .filter((orderItem) => {
+            return orderItem.order_id === action.order_id;
+        })
+        .forEach(function (orderItem) {
+            orderItem.state = action.state;
+        });
     return newState;
 }
 
@@ -29,14 +37,27 @@ function removeOrderItem(state, action) {
     return newState;
 }
 
+function removeOpenOrderItemsByOrder(state, action) {
+    var newState = Object.assign({}, state);
+    Object.keys(newState)
+        .map((orderItemId) => { return newState[orderItemId]; })
+        .filter((orderItem) => {
+            const shouldRemove = (action.orderId === orderItem.order_id) && (action.state === orderItem.state);
+            return !shouldRemove;
+        });
+    return newState;
+}
+
 export default function orderItemsReducer(state = {}, action = {}) {
     switch(action.type) {
     case ADD_ORDER_ITEM:
         return addOrderItem(state, action);
-    case CHANGE_ORDER_ITEM_STATE:
-        return changeOrderItemState(state, action);
+    case CHANGE_ORDER_ITEM_STATE_BY_ORDER_ID:
+        return changeOrderItemStateByOrderId(state, action);
     case REMOVE_ORDER_ITEM:
         return removeOrderItem(state, action);
+    case REMOVE_OPEN_ORDER_ITEMS_BY_ORDER:
+        return removeOpenOrderItemsByOrder(state, action);
     default:
         return state;
     }

--- a/src/reducers/order_items.spec.js
+++ b/src/reducers/order_items.spec.js
@@ -4,8 +4,8 @@ import {
     ORDER_ITEM_STATE_OPEN,
 
     addOrderItem,
-    changeOrderItemStateToFulfilled,
-    changeOrderItemStateToOpen,
+    changeOrderItemStateToFulfilledByOrderId,
+    changeOrderItemStateToOpenByOrderId,
     removeOrderItem,
 } from '../actions/order_item';
 
@@ -23,11 +23,12 @@ describe('reducers/order_items', () => {
     describe('when reducing addOrderItem', () => {
         it('should add open order item to empty state', () => {
             var state = {};
-            var action = addOrderItem(1111, 2222);
+            var action = addOrderItem(1111, 2222, 3333);
             expect(orderItemsReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             });
@@ -38,19 +39,22 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
-            var action = addOrderItem(3333, 4444);
+            var action = addOrderItem(4444, 5555, 6666);
             expect(orderItemsReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
-                3333: {
-                    id: 3333,
-                    menu_item_id: 4444,
+                4444: {
+                    id: 4444,
+                    menu_item_id: 5555,
+                    order_id: 6666,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             });
@@ -61,30 +65,33 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
-            var action = addOrderItem(1111, 3333);
+            var action = addOrderItem(1111, 4444, 5555);
             expect(orderItemsReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
-                    menu_item_id: 3333,
+                    menu_item_id: 4444,
+                    order_id: 5555,
                     state: ORDER_ITEM_STATE_OPEN,
                 }
             });
         });
     });
 
-    describe('when reducing changeOrderItemStateToFulfilled', () => {
-        it('should have no effect for nonexistent id', () => {
+    describe('when reducing changeOrderItemStateToFulfilledByOrderId', () => {
+        it('should have no effect for nonexistent matches', () => {
             var state = {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
-            var action = changeOrderItemStateToFulfilled(3333);
+            var action = changeOrderItemStateToFulfilledByOrderId(9999);
             expect(orderItemsReducer(state, action)).toEqual(state);
         });
 
@@ -93,14 +100,16 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
-            var action = changeOrderItemStateToFulfilled(1111);
+            var action = changeOrderItemStateToFulfilledByOrderId(3333);
             expect(orderItemsReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_FULFILLED,
                 },
             });
@@ -111,10 +120,11 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_FULFILLED,
                 },
             };
-            var action = changeOrderItemStateToFulfilled(1111);
+            var action = changeOrderItemStateToFulfilledByOrderId(3333);
             expect(orderItemsReducer(state, action)).toEqual(state);
         });
     });
@@ -125,28 +135,31 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_FULFILLED,
                 },
             };
-            var action = changeOrderItemStateToOpen(1111);
+            var action = changeOrderItemStateToOpenByOrderId(3333);
             expect(orderItemsReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             });
         });
 
-        it('should have no effect for fulfilled order item', () => {
+        it('should have no effect for open order item', () => {
             var state = {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
-            var action = changeOrderItemStateToOpen(1111);
+            var action = changeOrderItemStateToOpenByOrderId(3333);
             expect(orderItemsReducer(state, action)).toEqual(state);
         });
     });
@@ -157,6 +170,7 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
@@ -169,11 +183,13 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
                 3333: {
                     id: 3333,
                     menu_item_id: 4444,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
@@ -182,6 +198,7 @@ describe('reducers/order_items', () => {
                 3333: {
                     id: 3333,
                     menu_item_id: 4444,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             });
@@ -192,6 +209,7 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             };
@@ -200,6 +218,7 @@ describe('reducers/order_items', () => {
                 1111: {
                     id: 1111,
                     menu_item_id: 2222,
+                    order_id: 3333,
                     state: ORDER_ITEM_STATE_OPEN,
                 },
             });

--- a/src/reducers/orders.js
+++ b/src/reducers/orders.js
@@ -1,30 +1,16 @@
-import _ from 'underscore';
 import {
     ADD_ORDER,
-    ADD_ORDER_ITEMS,
     CHANGE_ORDER_STATE,
-    REMOVE_ALL_ORDER_ITEMS,
     REMOVE_ORDER,
-    REMOVE_ORDER_ITEMS,
 } from '../actions/order';
 
 function addOrder(state, action) {
     return Object.assign({}, state, {
         [action.id]: {
             id: action.id,
-            order_items: action.order_items,
             state: action.state,
         },
     });
-}
-
-function addOrderItems(state, action) {
-    var newState = Object.assign({}, state);
-    var order = newState[action.id];
-    if (order) {
-        order.order_items = _.union(order.order_items, action.order_items);
-    }
-    return newState;
 }
 
 function changeOrderState(state, action) {
@@ -36,27 +22,9 @@ function changeOrderState(state, action) {
     return newState;
 }
 
-function removeAllOrderItems(state, action) {
-    var newState = Object.assign({}, state);
-    var order = newState[action.id];
-    if (order) {
-        newState[action.id].order_items = [];
-    }
-    return newState;
-}
-
 function removeOrder(state, action) {
     var newState = Object.assign({}, state);
     delete newState[action.id];
-    return newState;
-}
-
-function removeOrderItems(state, action) {
-    var newState = Object.assign({}, state);
-    var order = newState[action.id] || {};
-    if (order) {
-        order.order_items = _.difference(order.order_items, action.order_items);
-    }
     return newState;
 }
 
@@ -64,16 +32,10 @@ export default function ordersReducer(state = {}, action = {}) {
     switch(action.type) {
     case ADD_ORDER:
         return addOrder(state, action);
-    case ADD_ORDER_ITEMS:
-        return addOrderItems(state, action);
     case CHANGE_ORDER_STATE:
         return changeOrderState(state, action);
-    case REMOVE_ALL_ORDER_ITEMS:
-        return removeAllOrderItems(state, action);
     case REMOVE_ORDER:
         return removeOrder(state, action);
-    case REMOVE_ORDER_ITEMS:
-        return removeOrderItems(state, action);
     default:
         return state;
     }

--- a/src/reducers/orders.spec.js
+++ b/src/reducers/orders.spec.js
@@ -7,14 +7,11 @@ import {
     ORDER_STATE_CANCELLED,
 
     addOrder,
-    addOrderItems,
     changeOrderStateToOpen,
     changeOrderStateToFulfilled,
     changeOrderStateToCompleted,
     changeOrderStateToCancelled,
-    removeAllOrderItems,
     removeOrder,
-    removeOrderItems,
 } from '../actions/order';
 
 describe('reducers/orders', function () {
@@ -30,11 +27,10 @@ describe('reducers/orders', function () {
     describe('when reducing addOrder', function () {
         it('should add open order item to empty state', () => {
             var state = {};
-            var action = addOrder(1111, 2222);
+            var action = addOrder(1111);
             expect(ordersReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
-                    order_items: [2222],
                     state: ORDER_STATE_NEW,
                 },
             });
@@ -44,20 +40,17 @@ describe('reducers/orders', function () {
             var state = {
                 1111: {
                     id: 1111,
-                    order_items: [2222],
                     state: ORDER_STATE_NEW,
                 },
             };
-            var action = addOrder(3333, 4444);
+            var action = addOrder(3333);
             expect(ordersReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
-                    order_items: [2222],
                     state: ORDER_STATE_NEW,
                 },
                 3333: {
                     id: 3333,
-                    order_items: [4444],
                     state: ORDER_STATE_NEW,
                 },
             });
@@ -67,67 +60,15 @@ describe('reducers/orders', function () {
             var state = {
                 1111: {
                     id: 1111,
-                    order_items: [2222],
-                    state: ORDER_STATE_NEW,
+                    state: ORDER_STATE_FULFILLED,
                 },
             };
-            var action = addOrder(1111, [3333]);
+            var action = addOrder(1111);
             expect(ordersReducer(state, action)).toEqual({
                 1111: {
                     id: 1111,
-                    order_items: [3333],
                     state: ORDER_STATE_NEW,
                 }
-            });
-        });
-    });
-
-    describe('when reducing addOrderItems', function () {
-        it('should have no effect with a nonexistent order id', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = addOrderItems(3333, 4444);
-            expect(ordersReducer(state, action)).toEqual(state);
-        });
-
-        it('should fill order_items for an order with none', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = addOrderItems(1111, [2222, 3333]);
-            expect(ordersReducer(state, action)).toEqual({
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            });
-        });
-
-        it('should merge order_items_for an order with existing', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = addOrderItems(1111, [2222, 4444, 5555]);
-            expect(ordersReducer(state, action)).toEqual({
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333, 4444, 5555],
-                    state: ORDER_STATE_NEW,
-                },
             });
         });
     });
@@ -218,38 +159,6 @@ describe('reducers/orders', function () {
         });
     });
 
-    describe('when reducing removeAllOrderItems', function () {
-        it('should have no effect with a nonexistent id', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = removeAllOrderItems(4444);
-            expect(ordersReducer(state, action)).toEqual(state);
-        });
-
-        it('should remove all order_items with an existing id', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = removeAllOrderItems(1111);
-            expect(ordersReducer(state, action)).toEqual({
-                1111: {
-                    id: 1111,
-                    order_items: [],
-                    state: ORDER_STATE_NEW,
-                },
-            });
-        });
-    });
-
     describe('when reducing removeOrder', function () {
         it('should have no effect with a nonexistent id', function () {
             var state = {
@@ -259,7 +168,7 @@ describe('reducers/orders', function () {
                     state: ORDER_STATE_NEW,
                 },
             };
-            var action = removeAllOrderItems(4444);
+            var action = removeOrder(4444);
             expect(ordersReducer(state, action)).toEqual(state);
         });
 
@@ -281,56 +190,6 @@ describe('reducers/orders', function () {
                 1111: {
                     id: 1111,
                     order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            });
-        });
-    });
-
-    describe('when reducing removeOrderItems', function () {
-        it('should have no effect with a nonexistent order id', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = removeOrderItems(3333, 4444);
-            expect(ordersReducer(state, action)).toEqual(state);
-        });
-
-        it('should have no effect with nonmatching order items', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = removeOrderItems(1111, [4444, 5555]);
-            expect(ordersReducer(state, action)).toEqual({
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333],
-                    state: ORDER_STATE_NEW,
-                },
-            });
-        });
-
-        it('should remove matching order items', function () {
-            var state = {
-                1111: {
-                    id: 1111,
-                    order_items: [2222, 3333, 4444],
-                    state: ORDER_STATE_NEW,
-                },
-            };
-            var action = removeOrderItems(1111, [2222, 4444, 5555]);
-            expect(ordersReducer(state, action)).toEqual({
-                1111: {
-                    id: 1111,
-                    order_items: [3333],
                     state: ORDER_STATE_NEW,
                 },
             });

--- a/src/reducers/root_reducer.spec.js
+++ b/src/reducers/root_reducer.spec.js
@@ -25,46 +25,17 @@ describe('reducers/root_reducer', () => {
                     price: 12.34,
                 },
             },
+            orders: {},
             order_items: {},
-            orders: {},
-        });
-    });
-
-    it('should return updated total state when adding an order_item', function () {
-        var state = {};
-        var menuAction = addMenuItem(1111, 'Burger', 'bgr', 12.34);
-        var orderItemAction = addOrderItem(2222, 1111);
-
-        state = rootReducer(state, menuAction);
-        expect(rootReducer(state, orderItemAction)).toEqual({
-            activity: {},
-            menu_items: {
-                1111: {
-                    id: 1111,
-                    name: 'Burger',
-                    shorthand: 'bgr',
-                    price: 12.34,
-                },
-            },
-            order_items: {
-                2222: {
-                    id: 2222,
-                    menu_item_id: 1111,
-                    state: ORDER_ITEM_STATE_OPEN,
-                },
-            },
-            orders: {},
         });
     });
 
     it('should return updated total state when adding an order', function () {
         var state = {};
         var menuAction = addMenuItem(1111, 'Burger', 'bgr', 12.34);
-        var orderItemAction = addOrderItem(2222, 1111);
-        var orderAction = addOrder(3333, 2222);
+        var orderAction = addOrder(2222);
 
         state = rootReducer(state, menuAction);
-        state = rootReducer(state, orderItemAction);
         expect(rootReducer(state, orderAction)).toEqual({
             activity: {},
             menu_items: {
@@ -75,18 +46,46 @@ describe('reducers/root_reducer', () => {
                     price: 12.34,
                 },
             },
-            order_items: {
+            orders: {
                 2222: {
                     id: 2222,
-                    menu_item_id: 1111,
-                    state: ORDER_ITEM_STATE_OPEN,
+                    state: ORDER_STATE_NEW,
+                },
+            },
+            order_items: {},
+        });
+    });
+
+    it('should return updated total state when adding an order_item', function () {
+        var state = {};
+        var menuAction = addMenuItem(1111, 'Burger', 'bgr', 12.34);
+        var orderAction = addOrder(2222);
+        var orderItemAction = addOrderItem(3333, 1111, 2222);
+
+        state = rootReducer(state, menuAction);
+        state = rootReducer(state, orderAction);
+        expect(rootReducer(state, orderItemAction)).toEqual({
+            activity: {},
+            menu_items: {
+                1111: {
+                    id: 1111,
+                    name: 'Burger',
+                    shorthand: 'bgr',
+                    price: 12.34,
                 },
             },
             orders: {
+                2222: {
+                    id: 2222,
+                    state: ORDER_STATE_NEW,
+                },
+            },
+            order_items: {
                 3333: {
                     id: 3333,
-                    order_items: [2222],
-                    state: ORDER_STATE_NEW,
+                    menu_item_id: 1111,
+                    order_id: 2222,
+                    state: ORDER_ITEM_STATE_OPEN,
                 },
             },
         });

--- a/src/selectors/menu_item.js
+++ b/src/selectors/menu_item.js
@@ -3,5 +3,8 @@ export function selectMenuItem(state, menuItemId) {
 }
 
 export function selectAllMenuItems(state) {
-    return Object.values(state.menu_items);
+    return Object.keys(state.menu_items)
+        .map((menuItemId) => {
+            return state.menuItems[menuItemId];
+        });
 }

--- a/src/selectors/order.js
+++ b/src/selectors/order.js
@@ -1,4 +1,4 @@
-import {selectDenormalizedOrderItems} from './order_item';
+import {selectDenormalizedOrderItemsByOrder} from './order_item';
 import {
     ORDER_STATE_NEW,
     ORDER_STATE_OPEN,
@@ -47,7 +47,7 @@ export function selectDenormalizedOrder(state, orderId) {
     }
     return (order === undefined) ? undefined : {
         id: order.id,
-        orderItems: selectDenormalizedOrderItems(state, order.order_items),
+        orderItems: selectDenormalizedOrderItemsByOrder(state, order.id),
         price: selectOrderTotalPrice(state, orderId),
         state: order.state,
         stateFormatted: selectOrderFormattedState(state, orderId),
@@ -55,12 +55,12 @@ export function selectDenormalizedOrder(state, orderId) {
 }
 
 export function selectFilteredOrders(state, filter) {
-    return Object.values(state.orders)
+    return Object.keys(state.orders)
+        .map((orderId) => { return state.orders[orderId]; })
         .filter(filter)
         .map((order) => {
             return order;
         });
-
 }
 
 export function selectOrder(state, orderId) {
@@ -88,7 +88,7 @@ export function selectOrderTotalPrice(state, orderId) {
     const order = selectOrder(state, orderId);
     return (order === undefined)
         ? undefined
-        : selectDenormalizedOrderItems(state, order.order_items)
+        : selectDenormalizedOrderItemsByOrder(state, order.id)
             .reduce((prior, orderItem) => {
                 return prior + orderItem.menuItem.price;
             }, 0);

--- a/src/selectors/order_item.js
+++ b/src/selectors/order_item.js
@@ -5,16 +5,18 @@ export function selectDenormalizedOrderItem(state, orderItemId) {
     return (orderItem === undefined) ? undefined : {
         id: orderItemId,
         menuItem: selectMenuItem(state, orderItem.menu_item_id),
+        state: orderItem.state,
     };
 }
 
-export function selectDenormalizedOrderItems(state, orderItemIds) {
-    return orderItemIds
-        .map((orderItemId) => {
-            return selectDenormalizedOrderItem(state, orderItemId);
-        })
+export function selectDenormalizedOrderItemsByOrder(state, orderId) {
+    return Object.keys(state.order_items)
+        .map((orderItemId) => { return state.order_items[orderItemId]; })
         .filter((orderItem) => {
-            return orderItem !== undefined;
+            return orderItem.order_id === orderId;
+        })
+        .map((orderItem) => {
+            return selectDenormalizedOrderItem(state, orderItem.id);
         });
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,5 @@ var stylesConfig = require('./webpack/styles.conf');
 module.exports = [
     appConfig,
     browserConfig,
-    browserMinConfig,
     stylesConfig,
 ];


### PR DESCRIPTION
https://trello.com/c/DezxdmG4/2-handle-a-case-where-someone-has-decided-to-change-their-order-once-they-get-to-the-window

Provides visual distinction between fulfilled and non-fulfilled order items on edit. Provides for different actions when saving or cancelling an order depending on whether it's new or it's existing.